### PR TITLE
Version 1.4.1

### DIFF
--- a/data/origins/powers/master_of_webs.json
+++ b/data/origins/powers/master_of_webs.json
@@ -78,10 +78,12 @@
                     "hit_action": {
                         "type": "origins:add_velocity",
                         "x": 0,
-                        "y": 0,
+                        "y": 0.5,
                         "z": 1.5,
-                        "operation": "set",
-                        "space": "local"
+                        "space": "local",
+                        "client": true,
+                        "server": false,
+                        "operation": "set"
                     },
                     "command_at_hit": "function originstweaks:web_shoot_hit",
                     "command_along_ray": "particle minecraft:dust 1 1 1 1 ~ ~ ~ 0 0 0 0.1 1 normal @a",

--- a/data/originstweaks/functions/arachnid_scale.mcfunction
+++ b/data/originstweaks/functions/arachnid_scale.mcfunction
@@ -1,20 +1,16 @@
 scale delay set 0
-scale delay set pehkui:base 0
-scale delay set pehkui:width 0
-scale delay set pehkui:height 0
-scale delay set pehkui:motion 0
 scale set pehkui:health 1
-scale set pehkui:visibility 0.75
+scale set pehkui:visibility 1
 scale set pehkui:motion 1
-scale set pehkui:knockback 1
-scale set pehkui:falling 0.75
+scale set pehkui:knockback 0.66
+scale set pehkui:falling 1
 scale set pehkui:flight 1
 scale set pehkui:reach 1
 scale set pehkui:block_reach 1
 scale set pehkui:entity_reach 1
 scale set pehkui:projectiles 1
-scale set pehkui:width 0.75
-scale set pehkui:height 0.75
+scale set pehkui:width 0.66
+scale set pehkui:height 0.66
 scale set pehkui:step_height 1
 scale set pehkui:drops 1
 scale set pehkui:base 1


### PR DESCRIPTION
+  Set additional velocity on web shoot to be client oriented
+  Set velocity to launch 0.5 upwards and 1.5 forwards
+  Tweaked height to fit under 1 block gaps