### PR TITLE
Version 1.6

### DIFF
--- a/data/origins/origins/blazeborn.json
+++ b/data/origins/origins/blazeborn.json
@@ -8,6 +8,9 @@
 		"origins:flame_particles",
 		"origins:damage_from_snowballs",
 		"origins:damage_from_potions",
+		"originstweaks:firecharged_projectile",
+		"originstweaks:blazing_touch",
+		"originstweaks:revved_up",
 		"originstweaks:blazeborn_sounds"
 	],
 	"icon": {

--- a/data/originstweaks/powers/blazing_touch.json
+++ b/data/originstweaks/powers/blazing_touch.json
@@ -24,6 +24,32 @@
             "power": "*:*_fire_hands_active"
         }
     },
+    "revved_fire_aspect": {
+        "type": "origins:target_action_on_hit",
+        "entity_action": {
+            "type": "origins:set_on_fire",
+            "duration": 40
+        },
+        "cooldown": 10,
+        "hud_render": {
+            "should_render": false
+        },
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:power_active",
+                    "power": "*:*_fire_hands_active"
+                },
+                {
+                    "type": "origins:resource",
+                    "resource": "*:revved_up_resource",
+                    "comparison": "!=",
+                    "compare_to": 0
+                }
+            ]
+        }
+    },
     "set_fire": {
         "type": "origins:active_self",
         "entity_action": {
@@ -71,7 +97,7 @@
             "power": "*:*_fire_hands_active"
         }
     },
-    "ignite_candle_cake": {
+    "ignite_others": {
         "type": "origins:action_on_block_use",
         "block_action": {
             "type": "origins:modify_block_state",

--- a/data/originstweaks/powers/blazing_touch.json
+++ b/data/originstweaks/powers/blazing_touch.json
@@ -1,0 +1,103 @@
+{
+    "type": "origins:multiple",
+    "name": "Blazing Touch",
+    "description": "Your hands are on fire. You have permanent Fire aspect V on your bare hands, and you can place fire by right clicking with empty hands. You also can light TNT.",
+    "fire_hands_active": {
+        "type": "origins:toggle",
+        "active_by_default": false,
+        "key": {
+            "key": "key.origins.primary_active"
+        }
+    },
+    "fire_aspekt": {
+        "type": "origins:target_action_on_hit",
+        "entity_action": {
+            "type": "origins:set_on_fire",
+            "duration": 20
+        },
+        "cooldown": 20,
+        "hud_render": {
+            "should_render": false
+        },
+        "condition": {
+            "type": "origins:power_active",
+            "power": "*:*_fire_hands_active"
+        }
+    },
+    "set_fire": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:raycast",
+            "distance": 3,
+            "block": true,
+            "entity": false,
+            "shape_type": "collider",
+            "fluid_handling": "none",
+            "block_action": {
+                "type": "origins:set_block",
+                "block": "minecraft:fire"
+            },
+            "hit_action": {
+                "type": "origins:play_sound",
+                "sound": "item.firecharge.use"
+            }
+        },
+        "cooldown": 10,
+        "hud_render": {
+            "should_render": false
+        },
+        "key": "key.use",
+        "condition": {
+            "type": "origins:power_active",
+            "power": "*:*_fire_hands_active"
+        }
+    },
+    "ignite_tnt": {
+        "type": "origins:action_on_block_use",
+        "block_action": {
+            "type": "origins:set_block",
+            "block": "minecraft:air"
+        },
+        "entity_action": {
+            "type": "origins:spawn_entity",
+            "entity_type": "minecraft:tnt"
+        },
+        "block_condition": {
+            "type": "origins:block",
+            "block": "minecraft:tnt"
+        },
+        "condition": {
+            "type": "origins:power_active",
+            "power": "*:*_fire_hands_active"
+        }
+    },
+    "ignite_candle_cake": {
+        "type": "origins:action_on_block_use",
+        "block_action": {
+            "type": "origins:modify_block_state",
+            "property": "lit",
+            "value": true
+        },
+        "block_condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:in_tag",
+                    "tag": "minecraft:candle_cakes"
+                },
+                {
+                    "type": "origins:in_tag",
+                    "tag": "minecraft:campfires"
+                },
+                {
+                    "type": "origins:in_tag",
+                    "tag": "originstweaks:candles"
+                }
+            ]
+        },
+        "condition": {
+            "type": "origins:power_active",
+            "power": "*:*_fire_hands_active"
+        }
+    }
+}

--- a/data/originstweaks/powers/blazing_touch.json
+++ b/data/originstweaks/powers/blazing_touch.json
@@ -1,12 +1,26 @@
 {
     "type": "origins:multiple",
     "name": "Blazing Touch",
-    "description": "Your hands are on fire. You have permanent Fire aspect V on your bare hands, and you can place fire by right clicking with empty hands. You also can light TNT.",
+    "description": "Your hands are on fire. You have permanent Fire aspect V on your bare hands, and you can place fire by right clicking with empty hands.",
     "fire_hands_active": {
         "type": "origins:toggle",
         "active_by_default": false,
         "key": {
-            "key": "key.origins.primary_active"
+            "key": "key.origins.secondary_active"
+        }
+    },
+    "fire_hands_resource": {
+        "type": "origins:resource",
+        "min": 0,
+        "max": 1,
+        "start_value": 1,
+        "hud_render": {
+            "sprite_location": "origins:textures/gui/community/huang/resource_bar_02.png",
+            "bar_index": 15,
+            "condition": {
+                "type": "origins:power_active",
+                "power": "*:*_fire_hands_active"
+            }
         }
     },
     "fire_aspekt": {
@@ -27,8 +41,19 @@
     "revved_fire_aspect": {
         "type": "origins:target_action_on_hit",
         "entity_action": {
-            "type": "origins:set_on_fire",
-            "duration": 40
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:set_on_fire",
+                    "duration": 40
+                },
+                {
+                    "type": "origins:change_resource",
+                    "resource": "*:revved_up_resource",
+                    "change": -16,
+                    "operation": "add"
+                }
+            ]
         },
         "cooldown": 10,
         "hud_render": {
@@ -59,39 +84,17 @@
             "entity": false,
             "shape_type": "collider",
             "fluid_handling": "none",
-            "block_action": {
-                "type": "origins:set_block",
-                "block": "minecraft:fire"
-            },
             "hit_action": {
                 "type": "origins:play_sound",
                 "sound": "item.firecharge.use"
-            }
+            },
+            "command_at_hit": "setblock ~ ~ ~ minecraft:fire"
         },
         "cooldown": 10,
         "hud_render": {
             "should_render": false
         },
         "key": "key.use",
-        "condition": {
-            "type": "origins:power_active",
-            "power": "*:*_fire_hands_active"
-        }
-    },
-    "ignite_tnt": {
-        "type": "origins:action_on_block_use",
-        "block_action": {
-            "type": "origins:set_block",
-            "block": "minecraft:air"
-        },
-        "entity_action": {
-            "type": "origins:spawn_entity",
-            "entity_type": "minecraft:tnt"
-        },
-        "block_condition": {
-            "type": "origins:block",
-            "block": "minecraft:tnt"
-        },
         "condition": {
             "type": "origins:power_active",
             "power": "*:*_fire_hands_active"
@@ -105,7 +108,7 @@
             "value": true
         },
         "block_condition": {
-            "type": "origins:and",
+            "type": "origins:or",
             "conditions": [
                 {
                     "type": "origins:in_tag",

--- a/data/originstweaks/powers/firecharged_projectile.json
+++ b/data/originstweaks/powers/firecharged_projectile.json
@@ -1,21 +1,49 @@
 {
-    "type": "origins:fire_projectile",
+    "type": "origins:multiple",
     "name": "Firecharged Projectile",
     "description": "Blazeborn are able to launch a burst of fireballs by pressing the primary key.",
-    "entity_type": "small_fireball",
-    "cooldown": 200,
-    "hud_render": {
-        "should_render": false
+    "not_revved": {
+        "type": "origins:fire_projectile",
+        "entity_type": "small_fireball",
+        "cooldown": 200,
+        "hud_render": {
+            "should_render": false
+        },
+        "count": 3,
+        "interval": 5,
+        "start_delay": 5,
+        "speed": 1.5,
+        "divergence": 2,
+        "sound": "entity.blaze.shoot",
+        "tag": "{NoGravity:1b}",
+        "key": {
+            "key": "key.origins.primary_active",
+            "continuous": true
+        }
     },
-    "count": 3,
-    "interval": 5,
-    "start_delay": 5,
-    "speed": 1.5,
-    "divergence": 2.0,
-    "sound": "entity.blaze.shoot",
-    "tag": "{NoGravity:1b}",
-    "key": {
-        "key": "key.origins.primary_active",
-        "continuous": true
+    "revved_up": {
+        "type": "origins:fire_projectile",
+        "entity_type": "small_fireball",
+        "cooldown": 50,
+        "hud_render": {
+            "should_render": false
+        },
+        "count": 3,
+        "interval": 4,
+        "start_delay": 0,
+        "speed": 2,
+        "divergence": 0,
+        "sound": "entity.blaze.shoot",
+        "tag": "{NoGravity:1b}",
+        "key": {
+            "key": "key.origins.primary_active",
+            "continuous": true
+        },
+        "condition": {
+            "type": "origins:resource",
+            "resource": "*:revved_up_resource",
+            "comparison": "!=",
+            "compare_to": 0
+        }
     }
 }

--- a/data/originstweaks/powers/firecharged_projectile.json
+++ b/data/originstweaks/powers/firecharged_projectile.json
@@ -1,0 +1,21 @@
+{
+    "type": "origins:fire_projectile",
+    "name": "Firecharged Projectile",
+    "description": "Blazeborn are able to launch a burst of fireballs by pressing the primary key.",
+    "entity_type": "small_fireball",
+    "cooldown": 200,
+    "hud_render": {
+        "should_render": false
+    },
+    "count": 3,
+    "interval": 5,
+    "start_delay": 5,
+    "speed": 1.5,
+    "divergence": 2.0,
+    "sound": "entity.blaze.shoot",
+    "tag": "{NoGravity:1b}",
+    "key": {
+        "key": "key.origins.primary_active",
+        "continuous": true
+    }
+}

--- a/data/originstweaks/powers/revved_up.json
+++ b/data/originstweaks/powers/revved_up.json
@@ -1,0 +1,90 @@
+{
+    "type": "origins:multiple",
+    "name": "Revved Up",
+    "description": "You can use a Firecharge to revv up your offensive abilities.",
+    "consume_firecharge": {
+        "type": "origins:active_self",
+        "entity_action": {
+            "type": "origins:and",
+            "actions": [
+                {
+                    "type": "origins:equipped_item_action",
+                    "equipment_slot": "mainhand",
+                    "action": {
+                        "type": "origins:consume",
+                        "amount": 1
+                    }
+                },
+                {
+                    "type": "origins:change_resource",
+                    "resource": "*:*_resource",
+                    "change": 128,
+                    "operation": "set"
+                },
+                {
+                    "type": "origins:playsound",
+                    "sound": "minecraft:entity.wither.shoot"
+                }
+            ]
+        },
+        "cooldown": 5,
+        "hud_render": {
+            "should_render": false
+        },
+        "key": {
+            "key": "key.use",
+            "continuous": true
+        },
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:equipped_item",
+                    "equipment_slot": "mainhand",
+                    "item_condition": {
+                        "type": "origins:ingredient",
+                        "ingredient": {
+                            "item": "minecraft:fire_charge"
+                        }
+                    }
+                },
+                {
+                    "type": "origins:resource",
+                    "resource": "*:*_resource",
+                    "comparison": "==",
+                    "compare_to": 0
+                }
+            ]
+        }
+    },
+    "resource": {
+        "type": "origins:resource",
+        "min": 0,
+        "max": 128,
+        "hud_render": {
+            "sprite_location": "origins:textures/gui/community/huang/resource_bar_01.png",
+            "bar_index": 7,
+            "condition":{
+                "type": "origins:resource",
+                "resource": "*:*_resource",
+                "comparison": "!=",
+                "compare_to": 0
+            }
+        }
+    },
+    "resource_decharge": {
+        "type": "origins:action_over_time",
+        "entity_action": {
+            "type": "origins:change_resource",
+            "resource": "*:*_resource",
+            "change": -1
+        },
+        "interval": 20,
+        "condition":{
+            "type": "origins:resource",
+            "resource": "*:*_resource",
+            "comparison": "!=",
+            "compare_to": 0
+        }
+    }
+}

--- a/data/originstweaks/powers/revved_up.json
+++ b/data/originstweaks/powers/revved_up.json
@@ -22,7 +22,7 @@
                     "operation": "set"
                 },
                 {
-                    "type": "origins:playsound",
+                    "type": "origins:play_sound",
                     "sound": "minecraft:entity.wither.shoot"
                 }
             ]

--- a/data/originstweaks/tags/blocks/candles
+++ b/data/originstweaks/tags/blocks/candles
@@ -1,0 +1,21 @@
+{
+    "replace": false,
+    "values": [
+        "block.minecraft.candle",
+        "block.minecraft.white_candle",
+        "block.minecraft.orange_candle",
+        "block.minecraft.magenta_candle",
+        "block.minecraft.light_blue_candle",
+        "block.minecraft.yellow_candle",
+        "block.minecraft.lime_candle",
+        "block.minecraft.pink_candle",
+        "block.minecraft.gray_candle",
+        "block.minecraft.light_gray_candle",
+        "block.minecraft.cyan_candle",
+        "block.minecraft.purple_candle",
+        "block.minecraft.blue_candle",
+        "block.minecraft.brown_candle",
+        "block.minecraft.green_candle",
+        "block.minecraft.red_candle"
+    ]
+}

--- a/data/originstweaks/tags/blocks/golden_blocks.json
+++ b/data/originstweaks/tags/blocks/golden_blocks.json
@@ -1,12 +1,12 @@
 {
-	"replace": false,
-	"values": [
-		"minecraft:gold_ore",
+    "replace": false,
+    "values": [
+        "minecraft:gold_ore",
         "minecraft:deepslate_gold_ore",
         "minecraft:nether_gold_ore",
         "minecraft:gold_block",
         "minecraft:raw_gold_block",
         "minecraft:gilded_blackstone",
         "minecraft:bell"
-	]
+    ]
 }


### PR DESCRIPTION
+ Added Power ``Blazing Hands`` to Blazeborn.
    + right clicking on a Block Places Fire.
    + Hitting Entities inflicts Fire Aspect V (X While revved up.).
+ Added Power ``Firecharged Projectile``.
    + Shoot 3 Inaccurate Fireballs with a second cooldown (5x 100% Accurate, 1/2 Second Cooldown while revved up).
+ Added Power ``Revved up``.
    + Consume 1 Firecharge for 128 seconds revved up.
    + Buffs Offensive Abilities when revved.