### PR TITLE
Version 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,110 +1,157 @@
 # OriginsTweaks Changelogs
 
+## [1.18.2](https://modrinth.com/mod/origins/version/1.4.1)
+
+### [Version 1.7 [Balancing, Mod Support & Fixes]]
+
+#### [Version 1.7.0 [Balancing, Mod Support & Fixes]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.7.0)
+
++ Updated Datapack to 1.18.2.
+  + Changed Pack Format to 9.
++ Removed Block Tag.
+  + Removed ``originstweaks:candle`` due to not being used.
++ Added Support for Charm.
+  + Added Modded Gold Blocks to ``origintweaks:golden_blocks``.
++ Fixed Team System
+  + Added property ``"hidden": true`` to avoid showing up on the Origin info card.
+  + Set ``seeFriendlyInvisibles`` of all Origin Teams to false.
+  + Fixed Issue with VanillaTweaks' Datapack ``AFK Display`` not reapplying Origins Teams after revoking AFK status.
++ Balanced Phantom Power ``Aurophobia``.
+  + Decreased the gold-debuff range from ``10`` to ``5``.
+  + Added Subpower ``golden_armor``.
+    + Restricts armor in tag ``originstweaks:golden_armor`` to be equipped.
+  + Added Item tag ``originstweaks:golden_armor``.
++ Balanced Shulk power ``Protective Shell``.
+  + Changed Sneak Cooldown from ``0 Ticks`` to ``2 ticks``.
++ Balanced Blazeborn Power ``Blazing Touch``.
+  + Increased non-revved Fire Aspect Cooldown from ``20 Ticks`` to ``200 Ticks``.
+  + Decreased Revved Cooldown from ``10 Ticks`` to ``0 Ticks``.
+  + Added blocks in tags ``minecraft:candles`` and ``minecraft:candle_cakes`` to be lit.
+  + Restrict Item use on Candle Cakes when sneaking to prevent it from being eaten when trying to light the candle.
++ Balanced Elytrian Power `Need for Mobility`
+  + Removed Restriction of equipping Armor higher than Iron Tier.
+  + Restricts usage of Elytra when wearing higher than Iron Tier.
++ Fixed Various Spelling Errors.
+
 ## [1.18.1](https://modrinth.com/mod/origins/version/1.3.1)
 
-[Version 1.6.3[Origin Teams and Reload Notification]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.3)
+### [Version 1.6 [Blazeborn Buff]]
+
+#### [Version 1.6.3 [Origin Teams and Reload Notification]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.3)
 
 + Added Automatic adding and joining of Origins Teams.
 + Added a ``/tellraw`` message once the Datapack has reloaded.
 + Fixed enderian sounds not working without support of datapack ``Better Enderian``.
 
-[Version 1.6.2 [Recipe Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.2)
+#### [Version 1.6.2 [Recipe Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.2)
 
 + Fixed Orb of Origins Recipe
-    + Rebased Folder data/minecraft/crafting to be data/crafting
-+ Fixed Merling Trident Recipe
-    + Removed Blacksmith Trident and added it as standard Recipe
+  + Rebased Folder data/minecraft/crafting to be data/crafting.
++ Fixed Merling Trident Recipe.
+  + Removed Blacksmith Trident.
 
-[Version 1.6.1 [Blazeborn Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.1)
+#### [Version 1.6.1 [Blazeborn Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6.1)
 
 + Added Power ``Thermal Lift`` to Blazeborn.
-    + Hover in Midair and move up and down by using jump or sneak.
+  + Hover in Midair and move up and down by using jump or sneak.
 + Fixed ``Blazing Touch``
-    + Removed Right clicking on Block to place power due to being unstable and bugged.
+  + Removed Right clicking on Block to place power due to being unstable and bugged.
 + Fixes some other small issues
-    + ``originstweaks:candles`` block tag is not a ``.json`` file.
-    + changed some stats for ``Firecharged Projectile`` power. 
+  + ``originstweaks:candles`` block tag is not a ``.json`` file.
+  + changed some stats for ``Firecharged Projectile`` power.
 
-## [Version 1.6 [Blazeborn Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6)
+#### [Version 1.6.0 [Blazeborn Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.6)
 
 + Added Power ``Blazing Touch`` to Blazeborn.
-    + right clicking on a Block Places Fire.
-    + Hitting Entities inflicts Fire Aspect V (X While revved up.).
+  + right clicking on a Block Places Fire.
+  + Hitting Entities inflicts Fire Aspect V (X While revved up.).
 + Added Power ``Firecharged Projectile``.
-    + Shoot 3 Inaccurate Fireballs with a second cooldown (5x 100% Accurate, 1/2 Second Cooldown while revved up).
+  + Shoot 3 Inaccurate Fireballs with a second cooldown (5x 100% Accurate, 1/2 Second Cooldown while revved up).
 + Added Power ``Revved up``.
-    + Consume 1 Firecharge for 128 seconds revved up.
-    + Buffs Offensive Abilities when revved.
+  + Consume 1 Firecharge for 128 seconds revved up.
+  + Buffs Offensive Abilities when revved.
 
-### [Version 1.5 [Shulker Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.5)
+### [Version 1.5 [Shulk Buff]]
 
-+ Added Power ``antigravity_bullet`` to shulk.
-    + Fires a Shulker Bullet upon pressing the Secondary ability key
-+ Added Power ``protective_shell`` to shulk.
-    + Grants 3 stages of resistance upon holding down shift
+#### [Version 1.5.0 [Shulker Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.5)
 
-### [Version 1.4.1 [Arachnid Fixes]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.4.1)
++ Added Power ``Antigravity Bullet`` to shulk.
+  + Fires a Shulker Bullet upon pressing the Secondary ability key
++ Added Power ``Protective Shell`` to shulk.
+  + Grants 3 stages of resistance upon holding down shift
 
-+  Set additional velocity on web shoot to be client oriented
-+  Set velocity to launch 0.5 upwards and 1.5 forwards
-+  Tweaked height to fit under 1 block gaps
+### [Version 1.4 [Arachnid Buff]]
 
-### [Version 1.4 [Arachnid Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.4)
+#### [Version 1.4.1 [Arachnid Fixes]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.4.1)
 
-+ Modified power ``origins:climbing``.
-    + Changed power to be activated using ``key.origins.secondary_active`` rather than ``key.origins.primary_active``.
-+ Modified power ``origins:master_of_webs``.
-    + Changed subpower "webbing" to be dependant on the String Resource.
-    + Added subpower "web_shoot".
-    + Modified subpower "web_crafting" to use 6 Strings to craft a Cobweb.
-    + Added subpower "string_resource".
-    + Added subpower "string_regenerate".
++ Set additional velocity on web shoot to be client oriented
++ Set velocity to launch 0.5 upwards and 1.5 forwards
++ Tweaked height to fit under 1 block gaps
+
+#### [Version 1.4.0 [Arachnid Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.4)
+
++ Modified power ``Climbing``.
+  + Changed power to be activated using ``key.origins.secondary_active`` rather than ``key.origins.primary_active``.
++ Modified power ``MAster of Webs``.
+  + Changed subpower "webbing" to be dependant on the String Resource.
+  + Added subpower "web_shoot".
+  + Modified subpower "web_crafting" to use 6 Strings to craft a Cobweb.
+  + Added subpower "string_resource".
+  + Added subpower "string_regenerate".
 + Fixed "Arthropod Appearance" to properly calculate falldamage delay and amount.
 
-### [Version 1.3.2 [Phantom Patch]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3.2)
+### [Version 1.3 [Phantom buff]]
 
-+   Modified power ``origins:burning_in_daylight``.
-    +   Fixed an Issue with Phantoms burning, even when wearing a Helmet.
-+   Modified power "Spectral Wail".
-    +   Fixed an Issue with the Glowing Effect visible to everyone.
+#### [Version 1.3.2 [Phantom Patch]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3.2)
 
-### [Version 1.3.1 [Arachnid Climbing Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3.1)
++ Modified power ``Burning in Daylight``.
+  + Fixed an Issue with Phantoms burning, even when wearing a Helmet.
++ Modified power `Spectral Wail`.
+  + Fixed an Issue with the Glowing Effect visible to everyone.
+
+#### [Version 1.3.1 [Arachnid Climbing Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3.1)
 
 + Added a Hud Render if `origins:climbing` is enabled.
 
-### [Version 1.3 [Phantom Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3)
+#### [Version 1.3.0 [Phantom Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.3)
 
 + Added power "Spectral Wail" to Phantom.
-    + Active ability that inflicts 30 seconds of Glowing to entities in 32 Blocks range
+  + Active ability that inflicts 30 seconds of Glowing to entities in 32 Blocks range
 + Added power "Aurophobia" to Phantom.
-    + Gold Debuffs: Golden Food is not edible, Golden Blocks are unphasable and give Debuffs in proximity, Golden Tools deal extra Damage to the Origin.
+  + Gold Debuffs: Golden Food is not edible, Golden Blocks are unphasable and give Debuffs in proximity, Golden Tools deal extra Damage to the Origin.
 + Removed power "Fragile" to balance out the damage modifier caused by "Aurophobia".
 
-### [Version 1.2.1 [Merling Blacksmith Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.2.1)
+### [Version 1.2 [Elytrian Buffs]]
+
+#### [Version 1.2.1 [Merling Blacksmith Fix]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.2.1)
 
 + Modified power "Merling Trident" to support Blacksmith Buffs.
 
-### [Verion 1.2 [Elytrian Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.2)
+#### [Version 1.2.0 [Elytrian Buff]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.2)
 
-+  Added power "Elytra Boost" to Elytrian.
-    +  Active Ability that gives a small forward boost if activated while gliding; similar to Rockets but weaker.
-+  Modified power `origins:light_armor` to support Armor up to Iron Tier.
++ Added power "Elytra Boost" to Elytrian.
+  + Active Ability that gives a small forward boost if activated while gliding; similar to Rockets but weaker.
++ Modified power `Need for Mobility` to support Armor up to Iron Tier.
 
-### [Version 1.1 [Basic Buffs]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.1)
+### [Version 1.1 [Basic Buffs]]
 
-+  Added power "Arthropod Appearance" to Arachnid.
-    +  Height change from 1.8 Blocks to 1.5 blocks.
-    +  Modified fall damage start calculatin after 30 Blocks, and half the amount.
-+  Added power "Merling Trident" to Merling.
-    +  Adds a craftable Trident for Merlings.
-+  Added power "Heaven's Grace" to Avian.
-    +  Spectral arrow deal extra Damage.
-+  Added support for datapack "Better Enderian"
-+  Added power "Hydro Knowledge" to Merling.
-    +  Tridents thrown while submerged in water deal more damage.
-+  Modified power `origins:slow_falling` to have a toggle.
+#### [Version 1.1.0 [Basic Buffs]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.1)
 
-### [Version 1.0 [Base Datapack]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.0)
++ Added power "Arthropod Appearance" to Arachnid.
+  + Height change from 1.8 Blocks to 1.5 blocks.
+  + Modified fall damage start calculatin after 30 Blocks, and half the amount.
++ Added power "Merling Trident" to Merling.
+  + Adds a craftable Trident for Merlings.
++ Added power "Heaven's Grace" to Avian.
+  + Spectral arrow deal extra Damage.
++ Added support for datapack "Better Enderian"
++ Added power "Hydro Knowledge" to Merling.
+  + Tridents thrown while submerged in water deal more damage.
++ Modified power `Slow Falling` to have a toggle.
 
-+  Added Ambience, Hurt, Death and retreat sounds for every Origin.
-+  Added Orb of Origin Crafting Recipe.
+### [Version 1.0 [Base Datapack]]
+
+#### [Version 1.0.0 [Base Datapack]](https://github.com/ChromexUnderscore/OriginsTweaks/releases/tag/1.0)
+
++ Added Ambience, Hurt, Death and retreat sounds for every Origin.
++ Added Orb of Origin Crafting Recipe.

--- a/data/originstweaks/functions/initialize_datapack.mcfunction
+++ b/data/originstweaks/functions/initialize_datapack.mcfunction
@@ -14,4 +14,12 @@ team modify enderian color dark_purple
 team modify merling color aqua
 team modify phantom color dark_aqua
 team modify shulk color light_purple
+team modify arachnid seeFriendlyInvisibles false
+team modify avian seeFriendlyInvisibles false
+team modify blazeborn seeFriendlyInvisibles false
+team modify elytrian seeFriendlyInvisibles false
+team modify enderian seeFriendlyInvisibles false
+team modify merling seeFriendlyInvisibles false
+team modify phantom seeFriendlyInvisibles false
+team modify shulk seeFriendlyInvisibles false
 tellraw @a "OriginsTweaks Initialized."

--- a/data/originstweaks/powers/antigravity_bullet.json
+++ b/data/originstweaks/powers/antigravity_bullet.json
@@ -1,7 +1,7 @@
 {
     "type": "origins:fire_projectile",
     "name": "Antigravity Bullet",
-    "description": "You can throw an Antigravity Bulletby pressing your secondary active key!",
+    "description": "You can throw an Antigravity Bullet by pressing your secondary active key!",
     "entity_type": "minecraft:shulker_bullet",
     "cooldown": 30,
     "hud_render": {

--- a/data/originstweaks/powers/arachnid_team.json
+++ b/data/originstweaks/powers/arachnid_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:arachnid_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/aurophobia.json
+++ b/data/originstweaks/powers/aurophobia.json
@@ -16,8 +16,12 @@
             "text": "You are unable to phase through Gold Blocks, Raw Gold Blocks and Gilded Blackstone."
         },
         {
+            "sprite": "origins:textures/gui/badge/info.png",
+            "text": "You cannot wear Golden Armor."
+        },
+        {
             "sprite": "origins:textures/gui/badge/star.png",
-            "text": "You will receive Weakness and Slowness III in 10 Blocks Distance to Gold-related Blocks."
+            "text": "You will receive Weakness and Slowness III in 5 Blocks Distance to Gold-related Blocks."
         }
     ],
     "proximity_stacking": {
@@ -47,7 +51,7 @@
                 "type": "origins:in_tag",
                 "tag": "originstweaks:golden_blocks"
             },
-            "radius": 10,
+            "radius": 5,
             "shape": "sphere",
             "comparison": ">=",
             "compare_to": 1
@@ -81,5 +85,33 @@
             "value": 0.25,
             "operation": "multiply_total"
         }
+    },
+    "gold_armor": {
+        "type": "origins:conditioned_restrict_armor",
+        "head": {
+            "type": "origins:ingredient",
+            "ingredient": {
+                "tag": "originstweaks:golden_armor"
+            }
+        },
+        "chest": {
+            "type": "origins:ingredient",
+            "ingredient": {
+                "tag": "originstweaks:golden_armor"
+            }
+        },
+        "legs": {
+            "type": "origins:ingredient",
+            "ingredient": {
+                "tag": "originstweaks:golden_armor"
+            }
+        },
+        "feet": {
+            "type": "origins:ingredient",
+            "ingredient": {
+                "tag": "originstweaks:golden_armor"
+            }
+        },
+        "tick_rate": 20
     }
 }

--- a/data/originstweaks/powers/avian_team.json
+++ b/data/originstweaks/powers/avian_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:avian_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/blazeborn_team.json
+++ b/data/originstweaks/powers/blazeborn_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:blazeborn_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/blazing_touch.json
+++ b/data/originstweaks/powers/blazing_touch.json
@@ -1,7 +1,7 @@
 {
     "type": "origins:multiple",
     "name": "Blazing Touch",
-    "description": "Youcan lit your hands on fire with your Secondary Key. When lit, you have permanent Fire aspect V on your bare hands, and you can light certain Blocks on fire.",
+    "description": "You can light your hands on fire with your Secondary Key. When lit, you have permanent Fire aspect V on your bare hands, and you can light certain Blocks on fire.",
     "fire_hands_active": {
         "type": "origins:toggle",
         "active_by_default": false,
@@ -29,7 +29,7 @@
             "type": "origins:set_on_fire",
             "duration": 20
         },
-        "cooldown": 20,
+        "cooldown": 200,
         "hud_render": {
             "should_render": false
         },
@@ -55,7 +55,7 @@
                 }
             ]
         },
-        "cooldown": 10,
+        "cooldown": 0,
         "hud_render": {
             "should_render": false
         },
@@ -75,7 +75,7 @@
             ]
         }
     },
-    "ignite_campfire": {
+    "ignite_stuff": {
         "type": "origins:action_on_block_use",
         "block_action": {
             "type": "origins:modify_block_state",
@@ -83,8 +83,21 @@
             "value": true
         },
         "block_condition": {
-            "type": "origins:in_tag",
-            "tag": "minecraft:campfires"
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:in_tag",
+                    "tag": "minecraft:campfires"
+                },
+                {
+                    "type": "origins:in_tag",
+                    "tag": "minecraft:candles"
+                },
+                {
+                    "type": "origins:in_tag",
+                    "tag": "minecraft:candle_cakes"
+                }
+            ]
         },
         "condition": {
             "type": "origins:and",
@@ -95,6 +108,28 @@
                 },
                 {
                     "type": "origins:sneaking"
+                }
+            ]
+        }
+    },
+    "restrict_candle_cake_use": {
+        "type": "origins:prevent_block_use",
+        "block_condition": {
+            "type": "origins:in_tag",
+            "tag": "minecraft:candle_cakes"
+        },
+        "condition": {
+            "type": "origins:and",
+            "conditions": [
+                {
+                    "type": "origins:sneaking"
+                },
+                {
+                    "type": "origins:equipped_item",
+                    "equipment_slot": "mainhand",
+                    "item_condition": {
+                        "type": "origins:empty"
+                    }
                 }
             ]
         }

--- a/data/originstweaks/powers/elytra_boost.json
+++ b/data/originstweaks/powers/elytra_boost.json
@@ -1,7 +1,7 @@
 {
   "type": "origins:active_self",
   "name": "Boosting",
-  "description": "Pressing your Secondary Power key while flying will provide you with a small forward boost.",
+  "description": "Pressing your Secondary Power key while gliding will provide you with a small forward boost.",
   "entity_action": {
     "type": "origins:and",
     "actions": [
@@ -12,7 +12,7 @@
       },
       {
         "type": "origins:execute_command",
-        "command": "playsound minecraft:entity.firework_rocket.launch master @s ~ ~ ~ 1 1"
+        "command": "playsound minecraft:entity.firework_rocket.launch player @s ~ ~ ~ 1 1"
       }
     ]
   },

--- a/data/originstweaks/powers/elytrian_team.json
+++ b/data/originstweaks/powers/elytrian_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:elytrian_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/enderian_team.json
+++ b/data/originstweaks/powers/enderian_team.json
@@ -1,5 +1,6 @@
 {
     "type": "origins:action_on_callback",
+    "hidden": true,
     "entity_action_added": {
         "type": "origins:execute_command",
         "command": "function originstweaks:enderian_team"

--- a/data/originstweaks/powers/feline_team.json
+++ b/data/originstweaks/powers/feline_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:feline_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/human_team.json
+++ b/data/originstweaks/powers/human_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:human_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/light_armor.json
+++ b/data/originstweaks/powers/light_armor.json
@@ -1,25 +1,50 @@
 {
-  "type": "origins:restrict_armor",
-  "name": "Need for Mobility",
-  "description": "You cannot wear any Armor heavier than Iron.",
-  "head": {
-    "type": "origins:armor_value",
-    "comparison": ">",
-    "compare_to": 2
-  },
-  "chest": {
-    "type": "origins:armor_value",
-    "comparison": ">",
-    "compare_to": 6
-  },
-  "legs": {
-    "type": "origins:armor_value",
-    "comparison": ">",
-    "compare_to": 5
-  },
-  "feet": {
-    "type": "origins:armor_value",
-    "comparison": ">",
-    "compare_to": 2
-  }
+    "type": "origins:prevent_elytra_flight",
+    "name": "Need for Mobility",
+    "description": "Armor heavier than Iron prevent you from gliding.",
+    "entity_action": {
+        "type": "origins:execute_command",
+        "command": "tellraw @s {\"text\": \"Your Armor is too heavy to be able to Fly!\", \"color\": \"red\"}"
+    },
+    "condition": {
+        "type": "origins:and",
+        "conditions": [
+            {
+                "type": "origins:equipped_item",
+                "equipment_slot": "head",
+                "item_condition": {
+                    "type": "origins:armor_value",
+                    "comparison": ">",
+                    "compare_to": 2
+                }
+            },
+            {
+                "type": "origins:equipped_item",
+                "equipment_slot": "chest",
+                "item_condition": {
+                    "type": "origins:armor_value",
+                    "comparison": ">",
+                    "compare_to": 6
+                }
+            },
+            {
+                "type": "origins:equipped_item",
+                "equipment_slot": "legs",
+                "item_condition": {
+                    "type": "origins:armor_value",
+                    "comparison": ">",
+                    "compare_to": 5
+                }
+            },
+            {
+                "type": "origins:equipped_item",
+                "equipment_slot": "feet",
+                "item_condition": {
+                    "type": "origins:armor_value",
+                    "comparison": ">",
+                    "compare_to": 2
+                }
+            }
+        ]
+    }
 }

--- a/data/originstweaks/powers/merling_team.json
+++ b/data/originstweaks/powers/merling_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:merling_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/phantom_team.json
+++ b/data/originstweaks/powers/phantom_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:phantom_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/powers/protective_shell.json
+++ b/data/originstweaks/powers/protective_shell.json
@@ -15,7 +15,7 @@
             "resource": "*:*_resource",
             "change": 1
         },
-        "cooldown": 0,
+        "cooldown": 2,
         "key": {
             "key": "key.sneak",
             "continuous": true

--- a/data/originstweaks/powers/shulk_team.json
+++ b/data/originstweaks/powers/shulk_team.json
@@ -1,7 +1,12 @@
 {
-    "type": "origins:action_on_callback",
-    "entity_action_added": {
+    "type": "origins:action_over_time",
+    "hidden": true,
+    "rising_action": {
         "type": "origins:execute_command",
         "command": "function originstweaks:shulk_team"
+    },
+    "interval": 20,
+    "condition": {
+        "type": "origins:moving"
     }
 }

--- a/data/originstweaks/tags/blocks/golden_blocks.json
+++ b/data/originstweaks/tags/blocks/golden_blocks.json
@@ -7,6 +7,10 @@
         "minecraft:gold_block",
         "minecraft:raw_gold_block",
         "minecraft:gilded_blackstone",
-        "minecraft:bell"
+        "minecraft:bell",
+        "charm:gold_lantern",
+        "charm:gold_soul_lantern",
+        "charm:gold_chain",
+        "charm:gold_bars"
     ]
 }

--- a/data/originstweaks/tags/items/golden_armor.json
+++ b/data/originstweaks/tags/items/golden_armor.json
@@ -1,0 +1,9 @@
+{
+	"replace": false,
+	"values": [
+		"minecraft:golden_helmet",
+        "minecraft:golden_chestplate",
+        "minecraft:golden_leggings",
+        "minecraft:golden_boots"
+	]
+}

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 8,
+    "pack_format": 9,
     "description": "Overhauls Vanilla Origins by adding Buffs, Debuffs and much more!"
   }
 }


### PR DESCRIPTION
+ Updated Datapack to 1.18.2.
  + Changed Pack Format to 9.
+ Removed Block Tag.
  + Removed ``originstweaks:candle`` due to not being used.
+ Added Support for Charm.
  + Added Modded Gold Blocks to ``origintweaks:golden_blocks``.
+ Fixed Team System
  + Added property ``"hidden": true`` to avoid showing up on the Origin info card.
  + Set ``seeFriendlyInvisibles`` of all Origin Teams to false.
  + Fixed Issue with VanillaTweaks' Datapack ``AFK Display`` not reapplying Origins Teams after revoking AFK status.
+ Balanced Phantom Power ``Aurophobia``.
  + Decreased the gold-debuff range from ``10`` to ``5``.
  + Added Subpower ``golden_armor``.
    + Restricts armor in tag ``originstweaks:golden_armor`` to be equipped.
  + Added Item tag ``originstweaks:golden_armor``.
+ Balanced Shulk power ``Protective Shell``.
  + Changed Sneak Cooldown from ``0 Ticks`` to ``2 ticks``.
+ Balanced Blazeborn Power ``Blazing Touch``.
  + Increased non-revved Fire Aspect Cooldown from ``20 Ticks`` to ``200 Ticks``.
  + Decreased Revved Cooldown from ``10 Ticks`` to ``0 Ticks``.
  + Added blocks in tags ``minecraft:candles`` and ``minecraft:candle_cakes`` to be lit.
  + Restrict Item use on Candle Cakes when sneaking to prevent it from being eaten when trying to light the candle.
+ Balanced Elytrian Power `Need for Mobility`
  + Removed Restriction of equipping Armor higher than Iron Tier.
  + Restricts usage of Elytra when wearing higher than Iron Tier.
+ Fixed Various Spelling Errors.